### PR TITLE
root - chore: upgrade GitHub Actions (breaking)

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
     - name: Use Node.js 22
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 22
         cache: 'pnpm'
@@ -44,7 +44,7 @@ jobs:
       run: pnpm test
       
     - name: Code Coverage
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: Hyphen/nodejs-sdk

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -70,6 +70,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
     - name: Use Node.js 22
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 22
         cache: 'pnpm'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,13 +27,13 @@ jobs:
         node-version: ['22', '24', '26']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install pnpm
       uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'


### PR DESCRIPTION
## Summary
Upgrade all GitHub Actions references to their latest major versions.

## Versions
- `actions/checkout` v3/v4 → v6
- `actions/setup-node` v4 → v6
- `codecov/codecov-action` v5 → v7
- `github/codeql-action` (init/autobuild/analyze) v2 → v4
- `pnpm/action-setup` v6.0.8 — already latest, unchanged (SHA-pinned)

## Tests
- [x] All four workflow YAML files parse (PyYAML)
- [x] `pnpm build` passes
- [x] `pnpm test` passes (231 passed, 1 skipped, 100% coverage)

## Breaking notes
Major-version bumps (hence the `(breaking)` suffix). No workflow inputs changed and no project code changes are required:

- **checkout v6 / setup-node v6 / codecov v7** move their action runtime to Node 24, which `ubuntu-latest` runners provide. setup-node v6 limits *automatic* caching to npm; this repo sets `cache: 'pnpm'` explicitly (with `pnpm/action-setup` running first), so caching is unaffected.
- **codeql v2 → v4**: CodeQL Action v2 is deprecated; v4 is the current supported line. The `init`/`autobuild`/`analyze` sub-actions and their `languages`/`category` inputs are unchanged.
- **codecov v7**: inputs `token`, `slug`, and `files` are confirmed present in the v7 `action.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Px42UMbWbPmi3d5YeKHwKa)_