### PR TITLE
ci: migrate npm release to OIDC trusted publishing with provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,9 @@ on:
     types: [released]
 
 permissions:
-  contents: read    
+  contents: read
+  # Required for npm trusted publishing (OIDC) and provenance attestations
+  id-token: write
 
 env:
   HYPHEN_PUBLIC_API_KEY: ${{ secrets.HYPHEN_PUBLIC_API_KEY }}
@@ -31,20 +33,23 @@ jobs:
       with:
         node-version: 22
         cache: 'pnpm'
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install Dependencies
       run: pnpm install
 
-    - name: Build    
+    - name: Build
       run: pnpm build
 
-    - name: Testing    
+    - name: Testing
       run: pnpm test
 
-    - name: Publish
-      run: |
-        npm config set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
-        npm publish --ignore-scripts
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    # Trusted publishing (OIDC) requires npm CLI >= 11.5.1, which is newer than
+    # the version bundled with Node.js 22.
+    - name: Update npm
+      run: npm install -g npm@latest
 
+    - name: Publish
+      # No NPM_TOKEN: authentication is handled via OIDC trusted publishing.
+      # Provenance attestations are generated from the OIDC identity.
+      run: npm publish --provenance --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@hyphen/sdk",
   "version": "3.1.0",
   "description": "Hyphen SDK for Node.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Hyphen/nodejs-sdk.git"
+  },
+  "homepage": "https://github.com/Hyphen/nodejs-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/Hyphen/nodejs-sdk/issues"
+  },
   "type": "module",
   "packageManager": "pnpm@11.6.0",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary

Migrates the `release` workflow from a long-lived `NPM_TOKEN` to **npm trusted publishing (OIDC)** and enables **provenance attestations** on every publish.

With trusted publishing, GitHub Actions mints a short-lived OIDC token that npm exchanges for ephemeral publish credentials — no secret to rotate or leak. Provenance attestations cryptographically link each published version back to the exact commit and workflow run that built it (the green "provenance" badge on npmjs.com).

## Changes

**`.github/workflows/release.yaml`**
- Add `id-token: write` permission (keeps `contents: read`) so the job can mint an OIDC token.
- Set `registry-url: 'https://registry.npmjs.org'` on `setup-node` (per npm's trusted-publishing guidance).
- Add an `Update npm` step (`npm install -g npm@latest`) — trusted publishing requires **npm CLI ≥ 11.5.1**, newer than the version bundled with Node.js 22.
- Publish via `npm publish --provenance --ignore-scripts` and **remove** the `NPM_TOKEN` secret and the `npm config set //registry.npmjs.org/:_authToken` step.

**`package.json`**
- Add a public `repository` field (plus `homepage` and `bugs`). A `repository` field that matches the source repo **case-sensitively** (`Hyphen/nodejs-sdk`) is **required** for npm to generate provenance attestations.

## ⚠️ Required one-time setup before the next release

The workflow change alone is **not sufficient** — a trusted publisher must be configured on npm, otherwise the publish will fail with an auth error. On <https://www.npmjs.com/package/@hyphen/sdk> → **Settings → Trusted Publisher**, add a GitHub Actions publisher with:

| Field | Value |
| --- | --- |
| Organization or user | `Hyphen` |
| Repository | `nodejs-sdk` |
| Workflow filename | `release.yaml` |
| Environment name | _(leave blank — none is used)_ |

The `NPM_TOKEN` repository secret can be deleted once this is in place.

## Verification
- `pnpm build` — succeeds
- `pnpm test` — lint clean, **233 tests pass**, **100% coverage** (statements/branches/functions/lines)

## References
- [npm trusted publishing with OIDC is generally available (GitHub Changelog)](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)
- [Trusted publishing for npm packages (npm Docs)](https://docs.npmjs.com/trusted-publishers/)
- [Generating provenance statements (npm Docs)](https://docs.npmjs.com/generating-provenance-statements/)

https://claude.ai/code/session_016qHimevBQJsTHzBxV7B2od

---
_Generated by [Claude Code](https://claude.ai/code/session_016qHimevBQJsTHzBxV7B2od)_