### PR TITLE
ci: publish release with pnpm instead of npm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,6 @@ jobs:
       with:
         node-version: 22
         cache: 'pnpm'
-        registry-url: 'https://registry.npmjs.org'
 
     - name: Install Dependencies
       run: pnpm install
@@ -44,12 +43,9 @@ jobs:
     - name: Testing
       run: pnpm test
 
-    # Trusted publishing (OIDC) requires npm CLI >= 11.5.1, which is newer than
-    # the version bundled with Node.js 22.
-    - name: Update npm
-      run: npm install -g npm@latest
-
     - name: Publish
-      # No NPM_TOKEN: authentication is handled via OIDC trusted publishing.
-      # Provenance attestations are generated from the OIDC identity.
-      run: npm publish --provenance --ignore-scripts
+      # No NPM_TOKEN: pnpm authenticates via OIDC trusted publishing and
+      # generates provenance attestations from the OIDC identity.
+      # --no-git-checks is required because the release runs from a detached
+      # tag checkout rather than a branch.
+      run: pnpm publish --provenance --no-git-checks --ignore-scripts


### PR DESCRIPTION
## Summary

Follow-up to #140 addressing @jaredwray's review feedback to **use pnpm** for the release publish step (consistent with `AGENTS.md`: *"Use `pnpm` instead of `npm` for all package management commands"*). Those comments landed as #140 was merged, so they weren't included there.

OIDC trusted publishing + provenance are **preserved** — only the publishing CLI changes from `npm` to `pnpm`.

## Changes (`.github/workflows/release.yaml`)

- Replace `npm publish --provenance` with **`pnpm publish --provenance --no-git-checks`**. `--no-git-checks` is needed because the release runs from a detached tag checkout (pnpm otherwise refuses to publish when not on a branch).
- **Drop** the `npm install -g npm@latest` step — it's no longer needed. pnpm **11.6.0** (already pinned via `packageManager` and installed by `pnpm/action-setup`) performs the OIDC token exchange for trusted publishing.
- **Remove** `registry-url` from `setup-node`. That input makes `setup-node` write `_authToken=${NODE_AUTH_TOKEN}` to `.npmrc`; with no token set, the literal placeholder is exactly what broke pnpm-11 OIDC publishing with a 404 ([pnpm/pnpm#11513](https://github.com/pnpm/pnpm/issues/11513), fixed in [#11526](https://github.com/pnpm/pnpm/pull/11526)). Removing it eliminates the root cause regardless of pnpm version, and matches the `writr` release flow.

`id-token: write` and the `repository` field in `package.json` (added in #140, required for provenance) are unchanged.

## Why this is safe with pnpm
- pnpm performs OIDC trusted publishing — the flow exists and was hardened in pnpm 11 ([#11513](https://github.com/pnpm/pnpm/issues/11513)/[#11526](https://github.com/pnpm/pnpm/pull/11526)); 11.6.0 includes the fix.
- No `.npmrc` token placeholder is written, so OIDC is the sole auth path when no token is present.

## Reminder (unchanged from #140)
The one-time **Trusted Publisher** config on npmjs.com for `@hyphen/sdk` (GitHub Actions → org `Hyphen`, repo `nodejs-sdk`, workflow `release.yaml`) is still required before the next release.

https://claude.ai/code/session_016qHimevBQJsTHzBxV7B2od

---
_Generated by [Claude Code](https://claude.ai/code/session_016qHimevBQJsTHzBxV7B2od)_