### PR TITLE
release: v4.0.0 (breaking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyphen/sdk",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Hyphen SDK for Node.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release summary
Major release: raises the minimum Node.js runtime to **22.18+/24+** (drops Node 20/21) and fixes QR-code creation with custom options. One PR, version bump only — `3.1.0 → 4.0.0`. (Branch synced with latest `main`, which now includes #141.)

## @hyphen/sdk@4.0.0 — 2026-06-12

Raises the minimum Node.js runtime to 22.18+/24+ (drops Node 20/21) and fixes QR-code creation with custom options.

### ⚠ BREAKING CHANGES
- **Minimum Node.js is now `^22.18.0 || >=24.0.0`** — Node 20 and 21 are no longer supported. The `engines.node` floor was raised (45d8439, #134) to match `tsdown@0.22.2` and `hookified@3.0.0` (865a5f3, #138), both of which require Node ≥22.18. Node 20 reached end-of-life in April 2026.
  Migration: upgrade your runtime to Node 22.18+ or Node 24+. No SDK code changes are required — the public API (`Hyphen`, `Toggle`, `Link`, `BaseService`, `HookifiedOptions`) is unchanged.
- **`hookified` upgraded 2.1.1 → 3.0.0 (major)** (865a5f3, #138). Surfaced for consumers who use `hookified` directly; its only breaking change is the Node ≥22.18 floor above. No SDK API changes.

### Bug Fixes
- **`createQrCode` now sends custom options as `multipart/form-data`** instead of JSON (6de740b, #137). Creating a QR code with `title`, `backgroundColor`, `color`, `size`, or `logo` previously failed with HTTP 400; these options now work. Calls without options are unaffected. Closes #133.

### Internal
- Migrate npm publish to OIDC trusted publishing with provenance attestations; drop the long-lived `NPM_TOKEN` (de6caf4, #140)
- Publish via `pnpm publish --provenance` instead of `npm`, dropping the `.npmrc` token placeholder while preserving OIDC trusted publishing + provenance (770aae9, #141)
- Pin all third-party GitHub Actions to full commit SHAs — supply-chain hardening (cb849f9, #139)
- Upgrade GitHub Actions to latest majors: checkout v6, setup-node v6, codecov v7, codeql v4 (8506977, #136)
- Upgrade TypeScript and build tooling: typescript 6.0.3, tsdown 0.22.2, @types/node 25.9.2 (78cebba, #134)
- Upgrade cacheable ecosystem: @cacheable/net 2.0.8 (now uses the runtime's native fetch), cacheable 2.3.5 (ec25054, #132)
- Adopt pnpm 11 via corepack and `allowBuilds`; consolidate the CI matrix to Node 22/24/26 (24a8dde, #132)
- Pin `pnpm/action-setup` to v6.0.8 by commit SHA (7d1930f, #132)
- Upgrade code quality dependencies: @biomejs/biome 2.4.16, vitest & coverage-v8 4.1.8 (9a242b2, #132)
- Quarantine the live-API QR custom-options test (later re-enabled by #137) and add stubbed unit coverage to hold 100% (781e1a2, #132)

### Contributors
- @jaredwray (8 PRs)

### Full List of Changes
- root - chore: upgrade code quality dependencies + adopt pnpm 11 / Node 22-26 CI by @jaredwray in #132
- root - chore: upgrade TypeScript and build tooling (breaking) by @jaredwray in #134
- fix(link): send QR code custom options as multipart/form-data by @jaredwray in #137
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #136
- root - chore: upgrade hookified (breaking) by @jaredwray in #138
- root - chore: defense - pin all GitHub Actions to full SHAs by @jaredwray in #139
- ci: migrate npm release to OIDC trusted publishing with provenance by @jaredwray in #140
- ci: publish release with pnpm instead of npm by @jaredwray in #141

**Full diff:** https://github.com/Hyphen/nodejs-sdk/compare/v3.1.0...v4.0.0

## Verification
- [x] `pnpm install` succeeds — lockfile unchanged by the version bump
- [x] `pnpm build` succeeds (target `node22.18.0`)
- [x] `pnpm test` passes locally — **233 tests, 100% coverage** (statements/branches/functions/lines)
- [x] Net diff vs `main` is the `package.json` version bump only

## Post-merge
- Merge, then **create a GitHub Release at tag `v4.0.0`** — the `release.yaml` workflow publishes to npm via `pnpm` (OIDC trusted publishing + provenance) on `release: [released]`.
- ⚠️ **Before** creating the Release: ensure the npm **Trusted Publisher** is configured for `@hyphen/sdk` (org `Hyphen`, repo `nodejs-sdk`, workflow `release.yaml`) per #140/#141 — otherwise the publish fails with an auth error. The `NPM_TOKEN` secret can be removed once it's in place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ax3tVRkBGaifDzp8xYcZhr)_