### PR TITLE
root - chore: pin CodeQL and pnpm/action-setup to commit SHAs

### DIFF
--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Install pnpm
-      uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
     - name: Use Node.js 22
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@24ea975727876cf496b1eb0c5b36e96e01600b51 # v4.37.0
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@24ea975727876cf496b1eb0c5b36e96e01600b51 # v4.37.0
+      uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -70,6 +70,6 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@24ea975727876cf496b1eb0c5b36e96e01600b51 # v4.37.0
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Install pnpm
-      uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
     - name: Use Node.js 22
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Install pnpm
-      uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](../blob/main/CONTRIBUTING.md) guidelines and [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)
- [ ] Tests for the changes have been added (for bug fixes/features) with 100% code coverage. — N/A: CI workflow pin correction, no source changes.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Chore (CI) — follow-up to #146. Corrects two GitHub Action pins that referenced the **annotated-tag object** SHA instead of the **commit** the tag points to. (The tag was peeled incorrectly during SHA resolution; GitHub Actions still resolved the runs, but the pins didn't match the documented release commit and would confuse SHA-pin tooling/audits.)

**Fix**
- `github/codeql-action` `24ea975` → `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` (the `v4.37.0` commit; init / autobuild / analyze)
- `pnpm/action-setup` `008330803` → `0ebf47130e4866e96fce0953f49152a61190b271` (the `v6.0.9` commit)

`actions/checkout@v7.0.0` and `actions/setup-node@v7.0.0` use lightweight tags and were already pinned to the correct commit; `codecov-action` unchanged.

Thanks @chatgpt-codex-connector for catching this on #146.

**Verification**
- [x] All 4 workflow YAML files parse
- [x] Every pin now resolves to the tag's commit SHA (`git ls-remote refs/tags/<tag>^{}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBX9CVqs5aLsNSb1haSF9i)_