### PR TITLE
release: v4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyphen/sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Hyphen SDK for Node.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release summary
Bug-fix and maintenance release: fixes flaky QR/link tests and the `qrCodeBytes` typed array, and refreshes tooling and runtime dependencies. Version bump only (`4.0.0 → 4.0.1`).

## @hyphen/sdk@4.0.1 — 2026-07-15

Fixes flaky QR/link tests and the `qrCodeBytes` typed array, and refreshes tooling and runtime dependencies.

### Bug Fixes
- eliminate flaky 404s in link/QR live tests and fix `qrCodeBytes` type (f6c2eee, #143)
  - ⚠️ `CreateQrCodeResponse.qrCodeBytes` is now `Uint8Array` (was `Uint16Array`, which widened each byte into corrupted, double-size image data). Corrects the returned bytes; changes the public type.

### Internal
- upgrade the cacheable ecosystem — `cacheable` 2.5.0, `@cacheable/net` 2.1.0 (c0de83a, #148)
- upgrade `hookified` 3.0.1 (358d7b1, #149)
- upgrade code-quality tooling — biome 2.5.3, vitest + coverage-v8 4.1.10, faker 10.5.0 (beeddf0, #144)
- align `@types/node` with the minimum supported Node major, 22 (a4fdf84, #145)
- upgrade GitHub Actions — checkout/setup-node v7, codeql v4.37.0, pnpm-action-setup v6.0.9 (765c244, #146)
- pin CodeQL and pnpm/action-setup to their commit SHAs (4962f52, #147)

### Contributors
- @jaredwray (7)

### Full List of Changes
- fix: eliminate flaky 404s in link/QR live tests and fix qrCodeBytes type by @jaredwray in #143
- root - chore: upgrade code quality dependencies by @jaredwray in #144
- root - chore: align @types/node with minimum supported Node by @jaredwray in #145
- root - chore: upgrade GitHub Actions (breaking) by @jaredwray in #146
- root - chore: pin CodeQL and pnpm/action-setup to commit SHAs by @jaredwray in #147
- root - chore: upgrade cacheable dependencies by @jaredwray in #148
- root - chore: upgrade hookified by @jaredwray in #149

**Full diff:** https://github.com/Hyphen/nodejs-sdk/compare/v4.0.0...v4.0.1

## Verification
- [x] `pnpm install --frozen-lockfile` succeeds (lockfile unaffected by the bump)
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes locally — **237 tests, 100% coverage** (Statements 396/396, Branches 194/194, Functions 98/98, Lines 392/392)
- [x] Net diff vs `main` is the `package.json` version bump only

## Post-merge
- Merge, then **create a GitHub Release at tag `v4.0.1`** — the `release.yaml` workflow publishes to npm via `pnpm publish --provenance` (OIDC trusted publishing + provenance) on `release: [released]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBX9CVqs5aLsNSb1haSF9i)_